### PR TITLE
Fix type error in member field array

### DIFF
--- a/components/MemberCardList.tsx
+++ b/components/MemberCardList.tsx
@@ -1,4 +1,4 @@
-import { Control, useFieldArray, Path, FieldValues, ArrayPath, FieldErrors } from 'react-hook-form';
+import { Control, useFieldArray, Path, FieldValues, ArrayPath, FieldErrors, UseFormWatch } from 'react-hook-form';
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { X, Plus } from "lucide-react";
@@ -15,6 +15,7 @@ interface MemberCardListProps<T extends FieldValues> {
   label?: string;
   roleType?: string;
   errors?: FieldErrors<T>;
+  watch?: UseFormWatch<T>;
 }
 
 export function MemberCardList<T extends FieldValues>({
@@ -23,6 +24,7 @@ export function MemberCardList<T extends FieldValues>({
   label = "Members",
   roleType = "",
   errors,
+  watch,
 }: MemberCardListProps<T>) {
   const { fields, append, remove } = useFieldArray({
     control,

--- a/components/MemberCardList.tsx
+++ b/components/MemberCardList.tsx
@@ -1,0 +1,56 @@
+import { Control, useFieldArray, Path, FieldValues, ArrayPath } from 'react-hook-form';
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { X, Plus } from "lucide-react";
+
+// Define the structure that array items should have
+interface MemberItem {
+  name: string;
+}
+
+interface MemberCardListProps<T extends FieldValues> {
+  control: Control<T>;
+  name: ArrayPath<T>;
+  label?: string;
+  roleType?: string;
+}
+
+export function MemberCardList<T extends FieldValues>({
+  control,
+  name,
+  label = "Members",
+  roleType = "",
+}: MemberCardListProps<T>) {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name,
+  });
+
+  const handleAddMember = () => {
+    append({ name: '' } as MemberItem & any);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">{label}</h3>
+        <Button type="button" onClick={handleAddMember} variant="outline" size="sm">
+          <Plus className="w-4 h-4 mr-1" /> เพิ่ม{roleType || 'สมาชิก'}
+        </Button>
+      </div>
+      {fields.map((field, index) => (
+        <Card key={field.id} className="p-4 flex items-center gap-2">
+          <Input
+            {...control.register(`${name}.${index}.name` as Path<T>)}
+            placeholder={`ชื่อ${roleType || 'สมาชิก'}`}
+            className="flex-1"
+          />
+          <Button type="button" variant="ghost" onClick={() => remove(index)}>
+            <X className="w-5 h-5 text-destructive" />
+          </Button>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/components/MemberCardList.tsx
+++ b/components/MemberCardList.tsx
@@ -1,8 +1,8 @@
-import { Control, useFieldArray, Path, FieldValues, ArrayPath } from 'react-hook-form';
-import { Input } from "@/components/ui/input";
+import { Control, useFieldArray, Path, FieldValues, ArrayPath, FieldErrors } from 'react-hook-form';
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { X, Plus } from "lucide-react";
+import { InputField } from "@/components/shared/Form/InputField";
 
 // Define the structure that array items should have
 interface MemberItem {
@@ -14,6 +14,7 @@ interface MemberCardListProps<T extends FieldValues> {
   name: ArrayPath<T>;
   label?: string;
   roleType?: string;
+  errors?: FieldErrors<T>;
 }
 
 export function MemberCardList<T extends FieldValues>({
@@ -21,6 +22,7 @@ export function MemberCardList<T extends FieldValues>({
   name,
   label = "Members",
   roleType = "",
+  errors,
 }: MemberCardListProps<T>) {
   const { fields, append, remove } = useFieldArray({
     control,
@@ -41,11 +43,16 @@ export function MemberCardList<T extends FieldValues>({
       </div>
       {fields.map((field, index) => (
         <Card key={field.id} className="p-4 flex items-center gap-2">
-          <Input
-            {...control.register(`${name}.${index}.name` as Path<T>)}
-            placeholder={`ชื่อ${roleType || 'สมาชิก'}`}
-            className="flex-1"
-          />
+          <div className="flex-1">
+            <InputField
+              control={control}
+              name={`${name}.${index}.name` as Path<T>}
+              label={`ชื่อ${roleType || 'สมาชิก'}`}
+              placeholder={`ชื่อ${roleType || 'สมาชิก'}`}
+              errors={errors}
+              hideLabel
+            />
+          </div>
           <Button type="button" variant="ghost" onClick={() => remove(index)}>
             <X className="w-5 h-5 text-destructive" />
           </Button>


### PR DESCRIPTION
Fixes TypeScript warning when appending new members in `MemberCardList`.

The `useFieldArray`'s `append` method struggled with type inference for generic `FieldValues`, requiring an explicit cast to `MemberItem & any` to satisfy TypeScript while maintaining functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3ae695f-da7a-46a2-9578-4a99dd292e27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3ae695f-da7a-46a2-9578-4a99dd292e27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

